### PR TITLE
feat: add status update method

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -34,7 +34,9 @@ class Photo(Document):
 
 class Status(EmbeddedDocument):
     timestamp = DateTimeField(default=datetime.utcnow)
-    type = StringField()
+    type = StringField(choices=[
+        'created_status', 'price_offer_status', 'price_accept_status', 'date_offer_status', 'date_accept_status', 'closed_status'
+    ], required=True)
 
     meta = {'allow_inheritance': True}
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -31,12 +31,18 @@ class Photo(Document):
                 setattr(self, field, kwargs[field])
         self.save()
 
+STATUS_TYPES = [
+    'created_status',
+    'price_offer_status',
+    'price_accept_status',
+    'date_offer_status',
+    'date_accept_status',
+    'closed_status'
+]
 
 class Status(EmbeddedDocument):
     timestamp = DateTimeField(default=datetime.utcnow)
-    type = StringField(choices=[
-        'created_status', 'price_offer_status', 'price_accept_status', 'date_offer_status', 'date_accept_status', 'closed_status'
-    ], required=True)
+    type = StringField(choices=STATUS_TYPES, required=True)
 
     meta = {'allow_inheritance': True}
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -29,7 +29,7 @@ class StatusSerializer(DocumentSerializer):
         required=True
     )
     timestamp = serializers.DateTimeField(read_only=True)
-    user_id = serializers.CharField(required=False, source="user_id.id",  read_only=True)
+    user_id = serializers.CharField(source="user_id.id", read_only=True)
     price = serializers.FloatField(required=False)
     date = serializers.DateTimeField(required=False)
     success = serializers.BooleanField(required=False)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -22,8 +22,8 @@ class StatusSerializer(DocumentSerializer):
         fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
 
     type = serializers.CharField(required=True)
-    timestamp = serializers.DateTimeField(default=datetime.utcnow)
-    user_id = serializers.CharField(required=False)
+    timestamp = serializers.DateTimeField(default=datetime.utcnow, read_only=True)
+    user_id = serializers.CharField(required=False, source="user_id.id",  read_only=True)
     price = serializers.FloatField(required=False)
     date = serializers.DateTimeField(required=False)
     success = serializers.BooleanField(required=False)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -35,8 +35,35 @@ class StatusSerializer(DocumentSerializer):
     success = serializers.BooleanField(required=False)
 
     class Meta:
-        model = Status  # Базовая модель
+        model = Status
         fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
+
+    def validate_status_type(self, value):
+        """Проверка, что тип статуса - строка"""
+        if not isinstance(value, str):
+            raise serializers.ValidationError("Address must be a string.")
+        return value
+
+    def validate_price(self, value):
+        """Проверка, что цена - положительное число"""
+        if value <= 0:
+            raise serializers.ValidationError("Price must be a positive number.")
+        return value
+
+    def validate_success(self, value):
+        """Проверка, что успешность закрытия - логическое значение"""
+        if not isinstance(value, bool):
+            raise serializers.ValidationError("Success must be a bool.")
+        return value
+
+    def validate_date(self, value):
+        """Проверка, что дата находится в формате UTC"""
+        try:
+            parsed_date = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            raise serializers.ValidationError(
+                "Date must be in ISO 8601 format with milliseconds and UTC.")
+        return parsed_date
 
 class CreatedStatusSerializer(DocumentSerializer):
     class Meta:

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -34,9 +34,20 @@ class StatusSerializer(DocumentSerializer):
     date = serializers.DateTimeField(required=False)
     success = serializers.BooleanField(required=False)
 
+    REQUIRED_FIELDS = {
+        "price_offer_status": "price",
+        "date_offer_status": "date",
+        "closed_status": "success"
+    }
+
     class Meta:
         model = Status
         fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
+
+    def validate(self, data):
+        if self.REQUIRED_FIELDS.get(data.get('type'), False) and not data.get(self.REQUIRED_FIELDS.get(data.get('type'), False)):
+            raise serializers.ValidationError(f"Missing required field: {self.REQUIRED_FIELDS.get(data.get('type'), False)}")
+        return data
 
     def validate_status_type(self, value):
         """Проверка, что тип статуса - строка"""

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -28,7 +28,7 @@ class StatusSerializer(DocumentSerializer):
         ],
         required=True
     )
-    timestamp = serializers.DateTimeField(default=datetime.utcnow, read_only=True)
+    timestamp = serializers.DateTimeField(read_only=True)
     user_id = serializers.CharField(required=False, source="user_id.id",  read_only=True)
     price = serializers.FloatField(required=False)
     date = serializers.DateTimeField(required=False)
@@ -47,12 +47,13 @@ class StatusSerializer(DocumentSerializer):
     def validate(self, data):
         if self.REQUIRED_FIELDS.get(data.get('type'), False) and not data.get(self.REQUIRED_FIELDS.get(data.get('type'), False)):
             raise serializers.ValidationError(f"Missing required field: {self.REQUIRED_FIELDS.get(data.get('type'), False)}")
+        data['timestamp'] = datetime.utcnow()
         return data
 
     def validate_status_type(self, value):
         """Проверка, что тип статуса - строка"""
         if not isinstance(value, str):
-            raise serializers.ValidationError("Address must be a string.")
+            raise serializers.ValidationError("Status type must be a string.")
         return value
 
     def validate_price(self, value):
@@ -67,14 +68,6 @@ class StatusSerializer(DocumentSerializer):
             raise serializers.ValidationError("Success must be a bool.")
         return value
 
-    def validate_date(self, value):
-        """Проверка, что дата находится в формате UTC"""
-        try:
-            parsed_date = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
-        except ValueError:
-            raise serializers.ValidationError(
-                "Date must be in ISO 8601 format with milliseconds and UTC.")
-        return parsed_date
 
 class CreatedStatusSerializer(DocumentSerializer):
     class Meta:

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -21,7 +21,17 @@ class StatusSerializer(DocumentSerializer):
         model = Status  # Базовая модель
         fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
 
-    type = serializers.CharField(required=True)
+    type = serializers.ChoiceField(
+        choices=[
+            'created_status',
+            'price_offer_status',
+            'price_accept_status',
+            'date_offer_status',
+            'date_accept_status',
+            'closed_status'
+        ],
+        required=True
+    )
     timestamp = serializers.DateTimeField(default=datetime.utcnow, read_only=True)
     user_id = serializers.CharField(required=False, source="user_id.id",  read_only=True)
     price = serializers.FloatField(required=False)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework_mongoengine.serializers import DocumentSerializer
 from rest_framework import serializers
 from bson import ObjectId
 from bson.dbref import DBRef
-from .models import ProductRequest, Photo, Status, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
+from .models import ProductRequest, Photo, Status, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus, STATUS_TYPES
 import os
 from datetime import datetime
 
@@ -18,14 +18,7 @@ class PhotoResponseSerializer(DocumentSerializer):
 
 class StatusSerializer(DocumentSerializer):
     type = serializers.ChoiceField(
-        choices=[
-            'created_status',
-            'price_offer_status',
-            'price_accept_status',
-            'date_offer_status',
-            'date_accept_status',
-            'closed_status'
-        ],
+        choices=STATUS_TYPES,
         required=True
     )
     timestamp = serializers.DateTimeField(read_only=True)

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -38,8 +38,8 @@ class StatusSerializer(DocumentSerializer):
         fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
 
     def validate(self, data):
-        if self.REQUIRED_FIELDS.get(data.get('type'), False) and not data.get(self.REQUIRED_FIELDS.get(data.get('type'), False)):
-            raise serializers.ValidationError(f"Missing required field: {self.REQUIRED_FIELDS.get(data.get('type'), False)}")
+        if self.REQUIRED_FIELDS.get(data.get('type'), False) and data.get(self.REQUIRED_FIELDS.get(data.get('type'))) is None:
+            raise serializers.ValidationError(f"Missing required field: {self.REQUIRED_FIELDS.get(data.get('type'))}")
         data['timestamp'] = datetime.utcnow()
         return data
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -2,8 +2,9 @@ from rest_framework_mongoengine.serializers import DocumentSerializer
 from rest_framework import serializers
 from bson import ObjectId
 from bson.dbref import DBRef
-from .models import ProductRequest, Photo, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
+from .models import ProductRequest, Photo, Status, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
 import os
+from datetime import datetime
 
 class PhotoSerializer(DocumentSerializer):
     class Meta:
@@ -14,6 +15,18 @@ class PhotoResponseSerializer(DocumentSerializer):
     class Meta:
         model = Photo
         fields = ['id']
+
+class StatusSerializer(DocumentSerializer):
+    class Meta:
+        model = Status  # Базовая модель
+        fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
+
+    type = serializers.CharField(required=True)
+    timestamp = serializers.DateTimeField(default=datetime.utcnow)
+    user_id = serializers.CharField(required=False)
+    price = serializers.FloatField(required=False)
+    date = serializers.DateTimeField(required=False)
+    success = serializers.BooleanField(required=False)
 
 class CreatedStatusSerializer(DocumentSerializer):
     class Meta:
@@ -46,7 +59,7 @@ class ClosedStatusSerializer(DocumentSerializer):
         fields = '__all__'
 
 class ProductRequestSerializer(DocumentSerializer):
-    statuses = serializers.ListField(read_only=True)
+    statuses = StatusSerializer(many=True, read_only=True)
     user_id = serializers.CharField(source="user_id.id", read_only=True)
     photos = serializers.ListField(child=serializers.CharField())
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -25,6 +25,11 @@ class PriceOfferStatusSerializer(DocumentSerializer):
         model = PriceOfferStatus
         fields = '__all__'
 
+class PriceAcceptStatusSerializer(DocumentSerializer):
+    class Meta:
+        model = PriceAcceptStatus
+        fields = '__all__'
+
 class DateOfferStatusSerializer(DocumentSerializer):
     class Meta:
         model = DateOfferStatus

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -17,10 +17,6 @@ class PhotoResponseSerializer(DocumentSerializer):
         fields = ['id']
 
 class StatusSerializer(DocumentSerializer):
-    class Meta:
-        model = Status  # Базовая модель
-        fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
-
     type = serializers.ChoiceField(
         choices=[
             'created_status',
@@ -37,6 +33,10 @@ class StatusSerializer(DocumentSerializer):
     price = serializers.FloatField(required=False)
     date = serializers.DateTimeField(required=False)
     success = serializers.BooleanField(required=False)
+
+    class Meta:
+        model = Status  # Базовая модель
+        fields = ['type', 'timestamp', 'user_id', 'price', 'date', 'success']
 
 class CreatedStatusSerializer(DocumentSerializer):
     class Meta:

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -2,7 +2,7 @@ from rest_framework_mongoengine.serializers import DocumentSerializer
 from rest_framework import serializers
 from bson import ObjectId
 from bson.dbref import DBRef
-from .models import ProductRequest, Photo, CreatedStatus, PriceOfferStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
+from .models import ProductRequest, Photo, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
 import os
 
 class PhotoSerializer(DocumentSerializer):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,9 @@ from .views import RequestViewSet, PhotoViewSet, DatabaseBackupViewSet
 
 urlpatterns = [
     path('requests/', RequestViewSet.as_view({'post': 'postRequests', 'get': 'getRequests'}), name='request_list_create'),
-    path('requests/<str:pk>/', RequestViewSet.as_view({'get': 'getRequestsByID', 'put': 'putRequests'}), name='request_detail'),
+    path('requests/<str:pk>/', RequestViewSet.as_view({'get': 'getRequestsByID'}), name='request_detail'),
+
+    path('requests/<str:pk>/statuses', RequestViewSet.as_view({'post': 'postRequestsStatuses'}), name='request_add_status'),
 
     path('photos/', PhotoViewSet.as_view({'post': 'postPhotos'}), name='photo_list_create'),
     path('photos/<str:pk>/', PhotoViewSet.as_view({'get': 'getPhotos'}), name='photo_detail'),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,7 @@ from .views import RequestViewSet, PhotoViewSet, DatabaseBackupViewSet
 
 urlpatterns = [
     path('requests/', RequestViewSet.as_view({'post': 'postRequests', 'get': 'getRequests'}), name='request_list_create'),
-    path('requests/<str:pk>/', RequestViewSet.as_view({'get': 'getRequestsByID'}), name='request_detail'),
+    path('requests/<str:pk>/', RequestViewSet.as_view({'get': 'getRequestsByID', 'put': 'putRequests'}), name='request_detail'),
 
     path('photos/', PhotoViewSet.as_view({'post': 'postPhotos'}), name='photo_list_create'),
     path('photos/<str:pk>/', PhotoViewSet.as_view({'get': 'getPhotos'}), name='photo_detail'),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -264,6 +264,9 @@ class RequestViewSet(ModelViewSet):
         else:
             last_initiator = product_request.user_id
 
+        if last_status.type == "closed_status":
+            return Response({"details": "Request already closed"}, status=status.HTTP_400_BAD_REQUEST)
+
         if status_type == "price_offer_status" and last_status.type not in ["created_status", "price_offer_status"]:
             return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -299,9 +302,6 @@ class RequestViewSet(ModelViewSet):
 
         if status_type == "date_accept_status" and (user.is_admin == last_initiator.is_admin):
             return Response({"details": "You can't accept date"}, status=status.HTTP_403_FORBIDDEN)
-
-        if last_status.type == "closed_status":
-            return Response({"details": "Request already closed"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             new_status = None

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -39,6 +39,12 @@ class RequestViewSet(ModelViewSet):
         "closed_status": lambda user, last_initiator, last_status, request: not user.is_admin and request.data.get("success"),
     }
 
+    REQUIRED_FIELDS = {
+        "price_offer_status": "price",
+        "date_offer_status": "date",
+        "closed_status": "success"
+    }
+
     @extend_schema(
         summary="Создать новую заявку",
         description="Позволяет пользователю создать новую заявку.",
@@ -284,6 +290,9 @@ class RequestViewSet(ModelViewSet):
         status_type = request.data.get("type")
         if not status_type:
             return Response({"details": "Missing field: type"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if self.REQUIRED_FIELDS.get(status_type, False) and request.data.get(self.REQUIRED_FIELDS.get(status_type)) is None:
+            return Response({"details": f"Missing field: {self.REQUIRED_FIELDS.get(status_type)}"}, status=status.HTTP_400_BAD_REQUEST)
 
         last_status = product_request.statuses[-1]
         if last_status.type != "created_status":

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -295,10 +295,7 @@ class RequestViewSet(ModelViewSet):
         if forbidden_check and forbidden_check(user, last_initiator):
             return Response({"details": "Forbidden action"}, status=status.HTTP_403_FORBIDDEN)
 
-        if status_type == "price_offer_status" and last_status.type == "price_offer_status" and (user.is_admin == last_initiator.is_admin):
-            return Response({"details": "You can't do two offers in a row"}, status=status.HTTP_403_FORBIDDEN)
-
-        if status_type == "date_offer_status" and last_status.type == "date_offer_status" and (user.is_admin == last_initiator.is_admin):
+        if status_type == last_status.type and user.is_admin == last_initiator.is_admin:
             return Response({"details": "You can't do two offers in a row"}, status=status.HTTP_403_FORBIDDEN)
 
         try:

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -268,6 +268,21 @@ class RequestViewSet(ModelViewSet):
         if status_type == "closed_status" and request.data.get("success") and last_status.type not in ["date_accept_status"]:
             return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
 
+        if status_type == "price_offer_status" and last_status.type != "price_offer_status" and not user.is_admin:
+            return Response({"details": "You can't initiate price offers"}, status=status.HTTP_403_FORBIDDEN)
+
+        if status_type == "date_offer_status" and last_status.type != "date_offer_status" and not user.is_admin:
+            return Response({"details": "You can't initiate date offers"}, status=status.HTTP_403_FORBIDDEN)
+
+        if status_type == "price_offer_status" and last_status.type == "price_offer_status" and (user.is_admin == last_initiator.is_admin):
+            return Response({"details": "You can't do two offers in a row"}, status=status.status.HTTP_403_FORBIDDEN)
+
+        if status_type == "date_offer_status" and last_status.type == "date_offer_status" and (user.is_admin == last_initiator.is_admin):
+            return Response({"details": "You can't do two offers in a row"}, status=status.status.HTTP_403_FORBIDDEN)
+
+        if status_type == "closed_status" and request.data.get("success") and not user.is_admin:
+            return Response({"details": "You can't confirm succesful closing"}, status=status.HTTP_403_FORBIDDEN)
+
         try:
             new_status = None
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -9,7 +9,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework import status
 from django.http import HttpResponse, JsonResponse
 from .models import ProductRequest, Photo, CreatedStatus, PriceOfferStatus, PriceAcceptStatus, DateOfferStatus, DateAcceptStatus, ClosedStatus
-from .serializers import ProductRequestSerializer, PhotoSerializer, PhotoResponseSerializer
+from .serializers import ProductRequestSerializer, PhotoSerializer, PhotoResponseSerializer, StatusSerializer
 from datetime import datetime, time
 from bson import ObjectId
 import json
@@ -235,39 +235,15 @@ class RequestViewSet(ModelViewSet):
     @extend_schema(
         summary="Обновить актуальный статус заявки",
         description="Позволяет добавить новый статус заявке. Обязательным является указание поля type. Остальные поля необходимо указывать в зависимости от типа заявки.",
-        request={
-        "application/json": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "description": "Тип статуса заявки (например, created_status, price_offer_status, date_accept_status)."
-                },
-                "price": {
-                    "type": "number",
-                    "description": "Цена для статуса price_offer_status (обязательно для этого типа)."
-                },
-                "date": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Дата для статуса date_offer_status (обязательно для этого типа)."
-                },
-                "success": {
-                    "type": "boolean",
-                    "description": "Результат закрытия заявки для статуса closed_status (обязательно для этого типа)."
-                }
-            },
-            "required": ["type"]
-        }
-    },
+        request=StatusSerializer,
         responses={
-            201: ProductRequestSerializer,  # Успешно создана заявка
-            400: ErrorResponseSerializer,  # Ошибка ввода данных
-            401: ErrorResponseSerializer,  # Пользователь не авторизован
-            403: ErrorResponseSerializer  # У пользователя недостаточно прав
+            201: StatusSerializer,
+            400: ErrorResponseSerializer,
+            401: ErrorResponseSerializer,
+            403: ErrorResponseSerializer
         }
     )
-    def putRequests(self, request, pk=None, *args, **kwargs):
+    def postRequestsStatuses(self, request, pk=None, *args, **kwargs):
         user = request.user
 
         try:
@@ -362,7 +338,7 @@ class RequestViewSet(ModelViewSet):
         except Exception as e:
             return Response({"details": "Missing fields for specific status type"}, status=status.HTTP_400_BAD_REQUEST)
 
-        response_serializer = self.get_serializer(product_request)
+        response_serializer = StatusSerializer(new_status)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -282,7 +282,8 @@ class RequestViewSet(ModelViewSet):
         except Exception as e:
             return Response({"details": "Missing fields for specific status type"}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({"details": "Status updated successfully"}, status=status.HTTP_200_OK)
+        response_serializer = self.get_serializer(product_request)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
 
 class PhotoViewSet(ModelViewSet):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -316,15 +316,6 @@ class RequestViewSet(ModelViewSet):
 
         new_status = None
 
-        STATUS_CREATORS = {
-            "price_offer_status": lambda data, user: PriceOfferStatus.create(price=data["price"], user_id=user.id),
-            "price_accept_status": lambda data, user: PriceAcceptStatus.create(user_id=user.id),
-            "date_offer_status": lambda data, user: DateOfferStatus.create(date=datetime.fromisoformat(data["date"]),
-                                                                           user_id=user.id),
-            "date_accept_status": lambda data, user: DateAcceptStatus.create(user_id=user.id),
-            "closed_status": lambda data, user: ClosedStatus.create(success=data["success"], user_id=user.id),
-        }
-
         creator = self.STATUS_CREATORS.get(status_type)
         new_status = creator(request.data, user)
         product_request.add_status(new_status)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -291,7 +291,7 @@ class RequestViewSet(ModelViewSet):
         if status_type == "closed_status" and request.data.get("success") and last_status.type != "date_accept_status":
             return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
 
-        forbidden_check = FORBIDDEN_INITIATIONS.get(status_type)
+        forbidden_check = self.FORBIDDEN_INITIATIONS.get(status_type)
         if forbidden_check and forbidden_check(user, last_initiator):
             return Response({"details": "Forbidden action"}, status=status.HTTP_403_FORBIDDEN)
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -305,7 +305,7 @@ class RequestViewSet(ModelViewSet):
             return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
 
         if status_type == "closed_status" and request.data.get("success") and last_status.type != "date_accept_status":
-            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"details": "You can't close request"}, status=status.HTTP_403_FORBIDDEN)
 
         forbidden_check = self.FORBIDDEN_INITIATIONS.get(status_type)
         if forbidden_check and forbidden_check(user, last_initiator, last_status, request):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -39,12 +39,6 @@ class RequestViewSet(ModelViewSet):
         "closed_status": lambda user, last_initiator, last_status, request: not user.is_admin and request.data.get("success"),
     }
 
-    REQUIRED_FIELDS = {
-        "price_offer_status": "price",
-        "date_offer_status": "date",
-        "closed_status": "success"
-    }
-
     @extend_schema(
         summary="Создать новую заявку",
         description="Позволяет пользователю создать новую заявку.",
@@ -288,11 +282,6 @@ class RequestViewSet(ModelViewSet):
             return Response({"details": "Not your request"}, status=status.HTTP_403_FORBIDDEN)
 
         status_type = request.data.get("type")
-        if not status_type:
-            return Response({"details": "Missing field: type"}, status=status.HTTP_400_BAD_REQUEST)
-
-        if self.REQUIRED_FIELDS.get(status_type, False) and request.data.get(self.REQUIRED_FIELDS.get(status_type)) is None:
-            return Response({"details": f"Missing field: {self.REQUIRED_FIELDS.get(status_type)}"}, status=status.HTTP_400_BAD_REQUEST)
 
         last_status = product_request.statuses[-1]
         if last_status.type != "created_status":

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -247,6 +247,27 @@ class RequestViewSet(ModelViewSet):
         if not status_type:
             return Response({"details": "Missing field: type"}, status=status.HTTP_400_BAD_REQUEST)
 
+        last_status = product_request.statuses[-1]
+        if last_status.type != "created_status":
+            last_initiator = last_status.user_id
+        else:
+            last_initiator = product_request.author
+
+        if status_type == "price_offer_status" and last_status.type not in ["created_status", "price_offer_status"]:
+            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if status_type == "price_accept_status" and last_status.type not in ["price_offer_status"]:
+            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if status_type == "date_offer_status" and last_status.type not in ["created_status", "date_offer_status", "price_accept_status"]:
+            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if status_type == "date_accept_status" and last_status.type not in ["date_offer_status"]:
+            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+
+        if status_type == "closed_status" and request.data.get("success") and last_status.type not in ["date_accept_status"]:
+            return Response({"details": "Wrong status order"}, status=status.HTTP_400_BAD_REQUEST)
+
         try:
             new_status = None
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -307,6 +307,8 @@ class RequestViewSet(ModelViewSet):
             new_status = None
 
             if status_type == "price_offer_status":
+                if request.data.get("price") <= 0:
+                    raise Exception
                 new_status = PriceOfferStatus.create(
                     price=request.data.get("price"),
                     user_id=user.id
@@ -325,6 +327,8 @@ class RequestViewSet(ModelViewSet):
                 new_status = DateAcceptStatus.create(user_id=user.id)
 
             elif status_type == "closed_status":
+                if request.data.get("success") is not True and request.data.get("success") is not False:
+                    raise Exception
                 new_status = ClosedStatus.create(
                     success=request.data.get("success"),
                     user_id=user.id


### PR DESCRIPTION
Уже реализовано:

* Проверка, что добавить статус может только админ или автор заявки
* Проверка на наличие всех нужных полей
* Проверка на последовательность:
  DateAccept только после DateOffer
  PriceAccept только после PriceOffer
  PriceOffer только после другого PriceOffer или Created
  DateOffer только после другого DateOffer или Created или PriceAccept
  Closed с success=True только после DateAccept
  Первый DateOffer и PriceOffer исходят от админа, дальше чередование, пока не будет Accept.
  Closed с success=True только от админа
  После ClosedStatus новых статусов добавить нельзя